### PR TITLE
🔄 Automate dates for community meetings

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ title: DAMAP - Simplifying Data Management Plans
     <div class="infobox__item">
         <div class="infobox__title">Next community meeting</div>
         <div class="infobox__data">
-            <span class="infobox__text"><time datetime="2026-01-27T14:30:00+0100">January 27, 14:30</time></span>
+            <span class="infobox__text"><time data-next-community-meeting="full"></time></span>
             <a href="community-meeting.ics" class="md-button sm">Calendar link</a>
         </div>
     </div>
@@ -80,10 +80,10 @@ The content and structure of DAMAP is based on Science Europe's Core Requirement
 <div class="calendar__block">
 <div class="calendar" markdown>
     <h2>Next community meeting</h2>
-    <time datetime="2026-01-27T14:30:00+0100">
-        <span class="calendar__dow">Tue</span>
-        <span class="calendar__day">Jan 27</span>
-        <span class="calendar__time">14:30</span>
+    <time data-next-community-meeting="block">
+        <span class="calendar__dow"></span>
+        <span class="calendar__day"></span>
+        <span class="calendar__time"></span>
     </time>
     <footer>
         <a href="community-meeting.ics" class="md-button md-button--full">Calendar link</a>

--- a/docs/next-community-meeting.js
+++ b/docs/next-community-meeting.js
@@ -1,0 +1,85 @@
+// Calculates the last Tuesday of a given month and year.
+// Formula explanation:
+// 1. Get the last day of the month.
+// 2. Determine its day of the week (0=Sun, 1=Mon, ..., 6=Sat).
+// 3. Calculate how many days to subtract to reach the last Tuesday.
+function getLastTuesdayofMonth(year, month) {
+  const lastDay = new Date(year, month + 1, 0);
+  const dow = lastDay.getDay(); // Day of week: 0 (Sun) to 6 (Sat).
+
+  // If last day is Wed(3), Thu(4), Fri(5), Sat(6), Sun(0), Mon(1):
+  // The distance to Tuesday is dow - 2 (if dow>=2) otherwise dow + 5.
+  const offset = (dow + 5) % 7; // number of days to go back to Tuesday
+  lastDay.setDate(lastDay.getDate() - offset);
+  return lastDay;
+}
+
+// Helper function to pad months/days to two digits.
+function pad(n) {
+  return n.toString().padStart(2, "0");
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const now = new Date();
+  let year = now.getFullYear();
+  let month = now.getMonth(); // 0-indexed: Jan=0, Feb=1, ..., Dec=11
+
+  let meetingDate = getLastTuesdayofMonth(year, month);
+  meetingDate.setHours(14, 30, 0, 0); // Set fixed time to 14:30:00.000
+
+  const meetingEnd = new Date(meetingDate);
+  meetingEnd.setHours(15, 0, 0, 0); // Meeting ends at 15:00
+  // If the meeting has already ended (after 15:00), move to next month.
+  if (now > meetingEnd) {
+    month += 1;
+    if (month > 11) {
+      // If December, roll over to January next year.
+      month = 0;
+      year += 1;
+    }
+    meetingDate = getLastTuesdayofMonth(year, month);
+    meetingDate.setHours(14, 30, 0, 0); // Set fixed time to 14:30:00.000
+    console.debug(meetingDate);
+  }
+  // Construct ISO 8601 string with timezone offset +01:00.
+  // Explicitly assembled to guarantee the correct time + timezone literal.
+  const isoDate = `${meetingDate.getFullYear()}-${pad(
+    meetingDate.getMonth() + 1
+  )}-${pad(meetingDate.getDate())}T14:30:00+01:00`;
+
+  // Homepage infobox.
+  document
+    .querySelectorAll('time[data-next-community-meeting="full"]')
+    .forEach((element) => {
+      element.setAttribute("datetime", isoDate);
+      element.textContent = meetingDate.toLocaleString("en-US", {
+        month: "long",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      });
+    });
+
+  // Calendar block.
+  document
+    .querySelectorAll('time[data-next-community-meeting="block"]')
+    .forEach((element) => {
+      element.setAttribute("datetime", isoDate);
+
+      const dow = element.querySelector(".calendar__dow");
+      const day = element.querySelector(".calendar__day");
+      const time = element.querySelector(".calendar__time");
+
+      if (dow)
+        dow.textContent = meetingDate.toLocaleDateString("en-US", {
+          weekday: "short",
+        });
+      if (day)
+        day.textContent = meetingDate.toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+        });
+      if (time) time.textContent = "14:30";
+    });
+});

--- a/docs/next-community-meeting.js
+++ b/docs/next-community-meeting.js
@@ -1,64 +1,120 @@
-// Calculates the last Tuesday of a given month and year.
-// Formula explanation:
-// 1. Get the last day of the month.
-// 2. Determine its day of the week (0=Sun, 1=Mon, ..., 6=Sat).
-// 3. Calculate how many days to subtract to reach the last Tuesday.
+// Meeting configuration
+const MEETING_START = { hour: 14, minute: 30 };
+const MEETING_END = { hour: 15, minute: 0 };
+
+// Locale and timezone settings
+const LOCALE = "en-GB";
+const TIMEZONE = "Europe/Vienna";
+
+// ==============================
+//          Date helpers
+// ==============================
+
+// Helper function to pad numbers to two digits.
+const pad = (num) => String(num).padStart(2, "0");
+
+// Get last Tuesday of a given month (month = 0-11)
 function getLastTuesdayofMonth(year, month) {
-  const lastDay = new Date(year, month + 1, 0);
-  const dow = lastDay.getDay(); // Day of week: 0 (Sun) to 6 (Sat).
+  const lastDay = new Date(year, month + 1, 0); // Last day of the month
+  const dow = lastDay.getDay(); // Determine day of week: 0 (Sun) to 6 (Sat).
 
   // If last day is Wed(3), Thu(4), Fri(5), Sat(6), Sun(0), Mon(1):
   // The distance to Tuesday is dow - 2 (if dow>=2) otherwise dow + 5.
-  const offset = (dow + 5) % 7; // number of days to go back to Tuesday
+  const offset = (dow + 5) % 7;
   lastDay.setDate(lastDay.getDate() - offset);
   return lastDay;
 }
 
-// Helper function to pad months/days to two digits.
-function pad(n) {
-  return n.toString().padStart(2, "0");
+// Builds meeting date object for the last Tuesday of the specified year and month.
+function buildMeetingDate(year, month) {
+  const date = getLastTuesdayofMonth(year, month);
+  date.setHours(MEETING_START.hour, MEETING_START.minute, 0, 0);
+  return date;
 }
+
+// Get timezone info: offset (machine-readable e.g. GMT+2) and abbreviation (human-readable e.g. GMT+1/CET)
+function getTimeZoneInfo(date) {
+  const tzOffset = new Intl.DateTimeFormat(LOCALE, {
+    timeZone: TIMEZONE,
+    timeZoneName: "shortOffset",
+  })
+    .formatToParts(date)
+    .find((p) => p.type === "timeZoneName").value;
+
+  const tzAbbr = new Intl.DateTimeFormat(LOCALE, {
+    timeZone: TIMEZONE,
+    timeZoneName: "short",
+  })
+    .formatToParts(date)
+    .find((p) => p.type === "timeZoneName").value;
+
+  return { tzOffset, tzAbbr };
+}
+
+// Build ISO 8601 datetime string with offset
+function toISO(date, offset) {
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:00${offset}`
+  );
+}
+
+// ==============================
+//           Main logic
+// ==============================
 
 document.addEventListener("DOMContentLoaded", () => {
   const now = new Date();
   let year = now.getFullYear();
   let month = now.getMonth(); // 0-indexed: Jan=0, Feb=1, ..., Dec=11
 
-  let meetingDate = getLastTuesdayofMonth(year, month);
-  meetingDate.setHours(14, 30, 0, 0); // Set fixed time to 14:30:00.000
+  // Format: YYYY-MM-DDTHH:MM:SS±HH:MM (timezone name)
+  let meetingDate = buildMeetingDate(year, month);
 
   const meetingEnd = new Date(meetingDate);
-  meetingEnd.setHours(15, 0, 0, 0); // Meeting ends at 15:00
-  // If the meeting has already ended (after 15:00), move to next month.
+  meetingEnd.setHours(MEETING_END.hour, MEETING_END.minute, 0, 0);
+
+  // If the meeting has already ended, move to next month.
   if (now > meetingEnd) {
-    month += 1;
+    month++;
+
     if (month > 11) {
       // If December, roll over to January next year.
       month = 0;
-      year += 1;
+      year++;
     }
-    meetingDate = getLastTuesdayofMonth(year, month);
-    meetingDate.setHours(14, 30, 0, 0); // Set fixed time to 14:30:00.000
-    console.debug(meetingDate);
+    meetingDate = buildMeetingDate(year, month);
   }
-  // Construct ISO 8601 string with timezone offset +01:00.
-  // Explicitly assembled to guarantee the correct time + timezone literal.
-  const isoDate = `${meetingDate.getFullYear()}-${pad(
-    meetingDate.getMonth() + 1
-  )}-${pad(meetingDate.getDate())}T14:30:00+01:00`;
 
-  // Homepage infobox.
+  const { tzOffset, tzAbbr } = getTimeZoneInfo(meetingDate);
+
+  // ISO 8601 date format: YYYY-MM-DDTHH:MM:SS±HH:MM used in datetime attribute.
+  const isoDate = toISO(meetingDate, tzOffset);
+
+  // Human-readable date: Month Day
+  const displayDate = meetingDate.toLocaleDateString(LOCALE, {
+    month: "long",
+    day: "numeric",
+    timeZone: TIMEZONE,
+  });
+
+  // Human-readable meeting time: HH:MM
+  const displayTime = meetingDate.toLocaleTimeString(LOCALE, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: TIMEZONE,
+  });
+
+  // Construct human-readable full datetime string: Month Day, HH:MM (GMT±X)
+  const fullDatetimeString = `${displayDate}, ${displayTime} (${tzAbbr})`;
+
+  // Full datetime (homepage infobox).
   document
     .querySelectorAll('time[data-next-community-meeting="full"]')
     .forEach((element) => {
       element.setAttribute("datetime", isoDate);
-      element.textContent = meetingDate.toLocaleString("en-US", {
-        month: "long",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false,
-      });
+      element.textContent = fullDatetimeString;
     });
 
   // Calendar block.
@@ -72,14 +128,18 @@ document.addEventListener("DOMContentLoaded", () => {
       const time = element.querySelector(".calendar__time");
 
       if (dow)
-        dow.textContent = meetingDate.toLocaleDateString("en-US", {
+        dow.textContent = meetingDate.toLocaleDateString(LOCALE, {
           weekday: "short",
+          timeZone: TIMEZONE,
         });
+
       if (day)
-        day.textContent = meetingDate.toLocaleDateString("en-US", {
+        day.textContent = meetingDate.toLocaleDateString(LOCALE, {
           month: "short",
           day: "numeric",
+          timeZone: TIMEZONE,
         });
-      if (time) time.textContent = "14:30";
+
+      if (time) time.textContent = `${displayTime} (${tzAbbr})`;
     });
 });

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,8 @@ theme:
     annotation: material/arrow-right-circle
 extra_css:
 - "custom.css"
+extra_javascript:
+  - next-community-meeting.js
 extra:
   generator: false
   footer_links:


### PR DESCRIPTION
Adds client-side logic to compute the next community meeting date as the last Tuesday of the month, with automatic rollover to the next month if the current meeting has already ended.

### Description

Implemented getLastTuesdayofMonth(year, month) using native Date APIs.
Added time window logic (14:30–15:00) and month/year rollover handling.
Generated ISO 8601 datetime string ~with fixed +01:00 offset.~
Updated <time> elements for both full and calendar views via `data-next-community-meeting` selectors.

### Notes

~Timezone offset is hardcoded (+01:00), not DST-aware.~
Uses client-local time for meeting cutoff logic.

### Issues
Closes #7 


### Update [2026-01-29T17:21Z]
- Simplified meeting date/time calculations.
- Uses `Intl.DateTimeFormat` to make timezone DST-aware (CET/CEST) instead of a fixed offset.
- Generates ISO 8601 `datetime` string for machine-readable attributes and formatted strings for human-readable display, both with the correct dynamic offset.