### PR TITLE
Update general options page

### DIFF
--- a/docs/manual/.pages
+++ b/docs/manual/.pages
@@ -5,3 +5,4 @@ nav:
 - configuration
 - cris
 - customization
+- migration

--- a/docs/manual/configuration/general.md
+++ b/docs/manual/configuration/general.md
@@ -8,10 +8,10 @@ hide:
 
 This section details the configuration options you can pass when [deploying the backend](../deployment/backend.md). As described [in the overview](index.md), we provide both the environment variable for stock deployment and the `application.yaml` variant for recompilation.
 
-| Environment variable  | application.yaml     | Description                                                                                                                                                   |
-|-----------------------|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DAMAP_ENV`           | `damap.env`          | Either `DEV` or `PROD`.                                                                                                                                       |
-| `DAMAP_ORIGINS`       | `damap.origins`      | The URL the backend should send out in the [CORS header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS). This should match your frontend URL. |
-| `DAMAP_FITS_URL`      | `damap.fits-url`     | URL to your [FITS service](../deployment/fits.md). (e.g. `http://fits-service:8080/fits`)                                                                     |
-| `DAMAP_GOTENBERG_URL` | `damap.gotenbergurl` | URL to your [Gotenberg service](../deployment/gotenberg.md). (e.g. `http://gotenberg:3000`)                                                                   |
-| `DAMAP_TITLE`         | `damap.title`        | The name of the DAMAP instance.                                                                                                                               |
+| Environment variable  | Description                                                                                                                                                   |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `QUARKUS_PROFILE`     | Comma seperated profiles, defaults to prod if left empty. Pass `multitenant` to allow for multiple tenants.                                                   |
+| `DAMAP_ENV`           | Either `DEV` or `PROD`.                                                                                                                                       |
+| `QUARKUS_HTTP_CORS_ORIGINS`| The URL the backend should send out in the [CORS header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS). This should match your frontend URL. |
+| `DAMAP_TITLE`         | The name of the DAMAP instance is used to set the HTML title.                                                                                                 |
+

--- a/docs/manual/migration/.pages
+++ b/docs/manual/migration/.pages
@@ -1,0 +1,2 @@
+title: Migration
+nav:

--- a/docs/manual/migration/configuration-variables.md
+++ b/docs/manual/migration/configuration-variables.md
@@ -1,0 +1,16 @@
+---
+title: Configuration variables
+---
+
+# Configuration variables
+
+With DAMAP v5.0.0, we are going away from reconfiguring the application through the `application.yaml` and are starting to only support environment variables. The table below will map from the old `application.yaml` values to the new environment variables.
+
+| Old Attribute (v4.x.x)           | Environment variable  | Description                                                                                                                                                   |
+|----------------------------------|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| _(None - previously not needed)_ | `QUARKUS_PROFILE`     | Comma seperated profiles, defaults to prod if left empty. Pass `multitenant` to allow for multiple tenants.                                                   |
+| `damap.env`                      | `DAMAP_ENV`           | Either `DEV` or `PROD`.                                                                                                                                       |
+| `damap.origins`                  | `QUARKUS_HTTP_CORS_ORIGINS`| The URL the backend should send out in the [CORS header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS). This should match your frontend URL. |
+| `damap.title`                    | `DAMAP_TITLE`         | The name of the DAMAP instance is used to set the HTML title.                                                                                                 |
+| `damap.fits-url`                 | `REST_FITS_MP_REST_URL`| URL to your [FITS service](../deployment/fits.md). (e.g. `http://fits-service:8080/fits`)                                                                                                                                                              |
+| `damap.gotenbergurl`             | `REST_GOTENBERG_MP_REST_URL` | URL to your [Gotenberg service](../deployment/gotenberg.md). (e.g. `http://gotenberg:3000`)                                                                                                                                                              |

--- a/docs/manual/migration/index.md
+++ b/docs/manual/migration/index.md
@@ -1,0 +1,7 @@
+---
+title: Migrating DAMAP to v5.0.0
+---
+
+# Migrating DAMAP to v5.0.0
+
+This guide outlines the steps for successfully migrating DAMAP from 4.x.x to 5.0.0 and higher or for migration from a locally deployed instance into the cloud. 


### PR DESCRIPTION
Updated the old variable to the new environemnt variables and removed the `application.yaml`, since we are moving away from that. Fits and Gotenberg will be in their respective section. Added guide for variable migrations.