### PR TITLE
Add small deployment page to migration section

### DIFF
--- a/docs/manual/migration/.pages
+++ b/docs/manual/migration/.pages
@@ -1,6 +1,7 @@
 title: Migration to v5.0.0
 nav:
 - Overview: index.md
+- Deployment: deployment.md
 - Access: access.md
 - Authentication: authentication.md
 - Configuration variables: configuration-variables.md

--- a/docs/manual/migration/deployment.md
+++ b/docs/manual/migration/deployment.md
@@ -1,0 +1,14 @@
+---
+title: Deployment changes
+---
+
+# Deployment changes
+
+With v5.0.0 we now officially only support dockerized and kubernetes based deployments.
+Making changes in the codebase of your own deployment to customize the application won't be actively supported anymore.
+Nothing stops you from doing it, but be aware of the risks - this might lead to overhead since you need to rebase
+everytime a new version is released.
+
+!!! note "Docker Setup"
+    DAMAPs docker setup has gotten a rather big overhaul in v5.0.0. For more information view the
+    [deployment documentation](../../deployment) and the further pages of this section.

--- a/docs/manual/migration/index.md
+++ b/docs/manual/migration/index.md
@@ -10,6 +10,8 @@ We offer an [example.env](https://github.com/damap-org/damap-backend/blob/next/e
 
 The following migration sections highlight the most important changes:
 
-- [Authentication](authentication.md)
+- [Deployment](deployment.md)
 - [Access](access.md)
+- [Authentication](authentication.md)
 - [Configuration Variables](configuration-variables.md)
+- [Customizations](customizations.md)


### PR DESCRIPTION
Small update to the migration section - small page about deployment changes and only supporting docker and kubernetes from now on.